### PR TITLE
Broken privacy URL fix

### DIFF
--- a/backend/public/telegram/locales/en.yaml
+++ b/backend/public/telegram/locales/en.yaml
@@ -24,7 +24,7 @@ help: |
   - Your <a href="${frontendDomain}">personal dashboard</a>
   - The <a href="https://github.com/matteojoliveau/convomark">full bot source code</a>
   - The <a href="https://trello.com/b/tHqNdkZD/convomark">project board</a>, to keep yourself up to date with the development process
-  - Our <a href="${frontendDomain}/privacy">privacy notice</a>
+  - Our <a href="${frontendDomain}privacy">privacy notice</a>
   - Our <a href="https://t.me/convomarksupportbot">support bot</a>, if you ever need some help or have a problem
 
   Have fun!

--- a/backend/public/telegram/locales/it.yaml
+++ b/backend/public/telegram/locales/it.yaml
@@ -24,7 +24,7 @@ help: |
   - La tua <a href="${frontendDomain}">dashboard personale</a>
   - Il <a href="https://github.com/matteojoliveau/convomark">sorgente completo del bot</a>
   - La <a href="https://trello.com/b/tHqNdkZD/convomark">board di progetto</a>, per essere aggiornato sugli sviluppi futuri
-  - La nostra <a href="${frontendDomain}/privacy">informativa sulla privacy</a>
+  - La nostra <a href="${frontendDomain}privacy">informativa sulla privacy</a>
   - Il nostro <a href="https://t.me/convomarksupportbot">bot di support</a>, qualora dovessi incontrare difficoltà o problemi
 
   Buon divertimento!


### PR DESCRIPTION
Broken URL on "Our privacy notice" during the `/help` call to the bot. 
It redirects to `//privacy` instead of just `/privacy`.